### PR TITLE
Extend plugin attributes with optional fields

### DIFF
--- a/BepInEx.Core/Contract/Attributes.cs
+++ b/BepInEx.Core/Contract/Attributes.cs
@@ -21,11 +21,15 @@ public class BepInPlugin : Attribute
     /// <param name="GUID">The unique identifier of the plugin. Should not change between plugin versions.</param>
     /// <param name="Name">The user friendly name of the plugin. Is able to be changed between versions.</param>
     /// <param name="Version">The specific version of the plugin.</param>
-    public BepInPlugin(string GUID, string Name, string Version)
+    /// <param name="Author">The author of the plugin.</param>
+    /// <param name="Link">The link to the plugin's website or repository.</param>
+    public BepInPlugin(string GUID, string Name, string Version, string Author = null, string Link = null)
     {
         this.GUID = GUID;
         this.Name = Name;
         this.Version = TryParseLongVersion(Version);
+        this.Author = Author;
+        this.Link = Link;
     }
 
     /// <summary>
@@ -44,6 +48,16 @@ public class BepInPlugin : Attribute
     ///     The specific version of the plugin.
     /// </summary>
     public Version Version { get; protected set; }
+
+    /// <summary>
+    ///     The author of the plugin.
+    /// </summary>
+    public string Author { get; protected set; }
+
+    /// <summary>
+    ///     The link to the plugin's website or repository.
+    /// </summary>
+    public string Link { get; protected set; }
 
     private static Version TryParseLongVersion(string version)
     {
@@ -70,9 +84,12 @@ public class BepInPlugin : Attribute
         if (attr == null)
             return null;
 
-        return new BepInPlugin((string) attr.ConstructorArguments[0].Value,
-                               (string) attr.ConstructorArguments[1].Value,
-                               (string) attr.ConstructorArguments[2].Value);
+        return new BepInPlugin(
+            (string) attr.ConstructorArguments[0].Value,
+            (string) attr.ConstructorArguments[1].Value,
+            (string) attr.ConstructorArguments[2].Value,
+            attr.ConstructorArguments.Count > 3 ? (string) attr.ConstructorArguments[3].Value : null,
+            attr.ConstructorArguments.Count > 4 ? (string) attr.ConstructorArguments[4].Value : null);
     }
 }
 

--- a/BepInEx.Core/Contract/PluginInfo.cs
+++ b/BepInEx.Core/Contract/PluginInfo.cs
@@ -56,6 +56,9 @@ public class PluginInfo : ICacheable
         bw.Write(Metadata.Name);
         bw.Write(Metadata.Version.ToString());
 
+        bw.Write(Metadata.Author ?? string.Empty);
+        bw.Write(Metadata.Link ?? string.Empty);
+
         var processList = Processes.ToList();
         bw.Write(processList.Count);
         foreach (var bepInProcess in processList)
@@ -79,7 +82,12 @@ public class PluginInfo : ICacheable
         TypeName = br.ReadString();
         Location = br.ReadString();
 
-        Metadata = new BepInPlugin(br.ReadString(), br.ReadString(), br.ReadString());
+        Metadata = new BepInPlugin(
+            br.ReadString(),
+            br.ReadString(),
+            br.ReadString(),
+            br.ReadString(),
+            br.ReadString());
 
         var processListCount = br.ReadInt32();
         var processList = new List<BepInProcess>(processListCount);

--- a/BepInEx.Preloader.Core/Patching/Attributes.cs
+++ b/BepInEx.Preloader.Core/Patching/Attributes.cs
@@ -14,11 +14,15 @@ public class PatcherPluginInfoAttribute : Attribute
     /// <param name="GUID">The unique identifier of the plugin. Should not change between plugin versions.</param>
     /// <param name="Name">The user friendly name of the plugin. Is able to be changed between versions.</param>
     /// <param name="Version">The specific version of the plugin.</param>
-    public PatcherPluginInfoAttribute(string GUID, string Name, string Version)
+    /// <param name="Author">The author of the plugin.</param>
+    /// <param name="Link">The link to the plugin's website or repository.</param>
+    public PatcherPluginInfoAttribute(string GUID, string Name, string Version, string Author = null, string Link = null)
     {
         this.GUID = GUID;
         this.Name = Name;
         this.Version = TryParseLongVersion(Version);
+        this.Author = Author;
+        this.Link = Link;
     }
 
     /// <summary>
@@ -37,6 +41,16 @@ public class PatcherPluginInfoAttribute : Attribute
     ///     The specific version of the plugin.
     /// </summary>
     public Version Version { get; protected set; }
+
+    /// <summary>
+    ///     The author of the plugin.
+    /// </summary>
+    public string Author { get; protected set; }
+
+    /// <summary>
+    ///     The link to the plugin's website or repository.
+    /// </summary>
+    public string Link { get; protected set; }
 
     private static Version TryParseLongVersion(string version)
     {
@@ -63,9 +77,12 @@ public class PatcherPluginInfoAttribute : Attribute
         if (attr == null)
             return null;
 
-        return new PatcherPluginInfoAttribute((string) attr.ConstructorArguments[0].Value,
-                                              (string) attr.ConstructorArguments[1].Value,
-                                              (string) attr.ConstructorArguments[2].Value);
+        return new PatcherPluginInfoAttribute(
+            (string) attr.ConstructorArguments[0].Value,
+            (string) attr.ConstructorArguments[1].Value,
+            (string) attr.ConstructorArguments[2].Value,
+            attr.ConstructorArguments.Count > 3 ? (string) attr.ConstructorArguments[3].Value : null,
+            attr.ConstructorArguments.Count > 4 ? (string) attr.ConstructorArguments[4].Value : null);
     }
 
     internal static PatcherPluginInfoAttribute FromType(Type type)


### PR DESCRIPTION
This adds `Author` and `Link` as optional attribute fields, meaning it's still valid if only the main 3 bepiex expects are present.

This should make prepatchers more consistent with normal plugins. 