### PR TITLE
refactor(BepisLoader): remove Hardware.Info dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,3 @@
 	path = HarmonyX
 	url = https://github.com/ResoniteModding/HarmonyX.git
 	branch = patchy
-[submodule "Hardware.Info"]
-	path = Hardware.Info
-	url = https://github.com/ResoniteModding/Hardware.Info.git
-	branch = patchy

--- a/Runtimes/NET/BepisLoader/BepisLoader.cs
+++ b/Runtimes/NET/BepisLoader/BepisLoader.cs
@@ -7,6 +7,7 @@ namespace BepisLoader;
 public class BepisLoader
 {
     internal static string resoDir = string.Empty;
+    private static readonly string tfmFolder = "net10.0";
     internal static AssemblyLoadContext alc = null!;
     static void Main(string[] args)
     {
@@ -17,6 +18,14 @@ public class BepisLoader
 #endif
 
         alc = new BepisLoadContext();
+
+        // Load System.Management explicitly for Windows to avoid PlatformNotSupportedException
+        var systemManagementPath = RuntimeInformation.RuntimeIdentifier.StartsWith("win")
+            ? new FileInfo(Path.Combine(resoDir, "runtimes", "win", "lib", tfmFolder, "System.Management.dll"))
+            : new FileInfo(Path.Combine(resoDir, "System.Management.dll"));
+
+        if (systemManagementPath.Exists)
+            alc.LoadFromAssemblyPath(systemManagementPath.FullName);
 
         // TODO: removing this breaks stuff, idk why
         AppDomain.CurrentDomain.AssemblyResolve += ResolveGameDll;

--- a/Runtimes/NET/BepisLoader/BepisLoader.csproj
+++ b/Runtimes/NET/BepisLoader/BepisLoader.csproj
@@ -12,16 +12,6 @@
         <DebugType>embedded</DebugType>
     </PropertyGroup>
 
-    <ItemGroup>
-        <Compile Remove="..\..\..\Hardware.Info\**" />
-        <EmbeddedResource Remove="..\..\..\Hardware.Info\**" />
-        <None Remove="..\..\..\Hardware.Info\**" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\..\..\Hardware.Info\Hardware.Info\Hardware.Info.csproj" />
-    </ItemGroup>
-
     <Target Name="RemoveExeAfterBuild" AfterTargets="Build">
         <Delete Condition="Exists('$(TargetDir)$(AssemblyName).exe')" Files="$(TargetDir)$(AssemblyName).exe" />
         <Delete Condition="Exists('$(TargetDir)$(AssemblyName)')"  Files="$(TargetDir)$(AssemblyName)" />


### PR DESCRIPTION
Remove the `Hardware.Info` submodule and its project reference from BepisLoader. Add explicit loading of `System.Management.dll` for Windows to avoid `PlatformNotSupportedException`.