### PR TITLE
feat(Logging): add BepisLoader version logging to chainloader startup

### DIFF
--- a/BepInEx.Core/Utility.cs
+++ b/BepInEx.Core/Utility.cs
@@ -28,6 +28,24 @@ public static class Utility
         SemanticVersioning.Version.Parse(MetadataHelper.GetAttributes<AssemblyInformationalVersionAttribute>(typeof(Utility).Assembly)[0]
                                     .InformationalVersion);
 
+    /// <summary>
+    ///     Gets the BepisLoader version if available.
+    /// </summary>
+    /// <returns>The version string, or null if BepisLoader is not found.</returns>
+    public static Version GetBepisLoaderVersion()
+    {
+        try
+        {
+            var bepisLoaderAsm = AppDomain.CurrentDomain.GetAssemblies()
+                .FirstOrDefault(a => a.GetName().Name == "BepisLoader");
+            return bepisLoaderAsm?.GetName().Version;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     private const string TRUSTED_PLATFORM_ASSEMBLIES = "TRUSTED_PLATFORM_ASSEMBLIES";
     private static bool? sreEnabled;
 

--- a/BepInEx.Preloader.Core/Logging/ChainloaderLogHelper.cs
+++ b/BepInEx.Preloader.Core/Logging/ChainloaderLogHelper.cs
@@ -50,6 +50,12 @@ public static class ChainloaderLogHelper
         Logger.Log(LogLevel.Info, $"System platform: {GetPlatformString()}");
         Logger.Log(LogLevel.Info,
                    $"Process bitness: {(PlatformUtils.ProcessIs64Bit ? "64-bit (x64)" : "32-bit (x86)")}");
+
+        var bepisLoaderVersion = Utility.GetBepisLoaderVersion();
+        if (bepisLoaderVersion != null)
+            Logger.Log(LogLevel.Info, $"Loader: BepisLoader {bepisLoaderVersion}");
+        else
+            Logger.Log(LogLevel.Info, "Loader: BepisLoader not found, version unknown");
     }
 
     private static string GetPlatformString()


### PR DESCRIPTION
Add utility method to detect BepisLoader assembly and retrieve its version, then log this information during chainloader initialization.