### PR TITLE
refactor(build): remove BepisLoader.runtimeconfig.json overwrites

### DIFF
--- a/Runtimes/NET/BepisLoader/LinuxBootstrap.sh
+++ b/Runtimes/NET/BepisLoader/LinuxBootstrap.sh
@@ -82,25 +82,6 @@ main()
 	chmod +x "$DOTNET_EXECUTABLE"
 
 
-	# Replace Windows runtime config with Linux runtime config for BepisLoader
-	if [ -f "./BepisLoader.runtimeconfig.json" ]; then
-		cat > "./BepisLoader.runtimeconfig.json" <<-'EOF'
-		{
-		  "runtimeOptions": {
-		    "tfm": "net10.0",
-		    "framework": {
-		      "name": "Microsoft.NETCore.App",
-		      "version": "10.0.0"
-		    },
-		    "configProperties": {
-		      "System.Reflection.Metadata.MetadataUpdater.IsSupported": false,
-		      "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization": false
-		    }
-		  }
-		}
-		EOF
-	fi
-
 	echo "Parsing hookfxr parameters"
 	HOOKFXR_STATUS=""
 	TARGET_ASSEMBLY=""

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -467,39 +467,6 @@ public sealed class MakeDistTask : FrostingTask<BuildContext>
                         ctx.Log.Warning($"hookfxr cache directory not found: {hookfxrPath}");
                     }
 
-                    // Replace contents of BepisLoader.runtimeconfig.json with the proper framework configuration for windows
-                    var runtimeConfigPath = targetDir.CombineWithFilePath("BepisLoader.runtimeconfig.json");
-                    if (ctx.FileExists(runtimeConfigPath))
-                    {
-                        var runtimeConfig = """
-                            {
-                              "runtimeOptions": {
-                                "tfm": "net10.0",
-                                "frameworks": [
-                                  {
-                                    "name": "Microsoft.NETCore.App",
-                                    "version": "10.0.0"
-                                  },
-                                  {
-                                    "name": "Microsoft.WindowsDesktop.App",
-                                    "version": "10.0.0"
-                                  }
-                                ],
-                                "configProperties": {
-                                  "System.Reflection.Metadata.MetadataUpdater.IsSupported": false,
-                                  "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization": false
-                                }
-                              }
-                            }
-                            """;
-                        System.IO.File.WriteAllText(runtimeConfigPath.FullPath, runtimeConfig);
-                        ctx.Log.Information("Updated BepisLoader.runtimeconfig.json with proper framework configuration");
-                    }
-                    else
-                    {
-                        ctx.Log.Warning($"BepisLoader.runtimeconfig.json not found at: {runtimeConfigPath}");
-                    }
-
                     // Copy icon.ico from BepisLoader project directory to BepInEx folder
                     var iconPath = ctx.RootDirectory.CombineWithFilePath("Runtimes/NET/BepisLoader/icon.ico");
                     if (ctx.FileExists(iconPath))


### PR DESCRIPTION
The assembly dependency resolver refactor (#32) eliminates the need to modify `BepisLoader.runtimeconfig.json` at build time or runtime.
